### PR TITLE
updated to the proper map theme

### DIFF
--- a/src/components/pages/DataViz/RenderMap.js
+++ b/src/components/pages/DataViz/RenderMap.js
@@ -175,7 +175,6 @@ const RenderMap = () => {
       setFullscreen(false);
     }
   }
-
   return (
     <div className="mapbox-react">
       <ReactMapGL
@@ -185,7 +184,7 @@ const RenderMap = () => {
         {...viewport}
         width={screenWidth}
         height={screenHeight}
-        mapStyle="mapbox://styles/jgertig/ckeughi4a1plr19qqsarcddky"
+        mapStyle="mapbox://styles/meloegel/ckfzuryk61c5z19o8pzd6o5fe"
         onViewportChange={handleViewportChange}
         mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
         interactiveLayerIds={['data']}


### PR DESCRIPTION
Updated the map theme to one more suited per the stakeholders request. The current architecture of the mapbox component makes it rather difficult to add the ability to cycle between themes easily. Something we are still considering adapting in the future while we work on the project. however if we choose to keep this fix, we decided to make a readme file to explain to future cohorts working on the project how to create their own custom theme. 