### PR TITLE
fixes default zoom

### DIFF
--- a/src/components/pages/DataViz/BridgeImage.js
+++ b/src/components/pages/DataViz/BridgeImage.js
@@ -19,8 +19,8 @@ const BridgeImage = ({
         onClick={() => {
           setDetailsData(marker);
           setViewport({
-            latitude: marker.lat,
-            longitude: marker.long,
+            latitude: marker.Lat,
+            longitude: marker.Long,
             transitionDuration: 1500,
             transitionInterpolator: new LinearInterpolator(),
             zoom: 11,

--- a/src/components/pages/DataViz/Markers.js
+++ b/src/components/pages/DataViz/Markers.js
@@ -10,9 +10,9 @@ const Markers = React.memo(({ bridgeData, setViewport }) => {
     <>
       {bridgeData &&
         bridgeData.map((marker, index) => {
-          return marker.lat & marker.long ? (
+          return marker.Lat & marker.Long ? (
             <div key={index}>
-              <Marker latitude={marker.lat} longitude={marker.long}>
+              <Marker latitude={marker.Lat} longitude={marker.Long}>
                 <BridgeImage
                   setViewport={setViewport}
                   marker={marker}
@@ -32,15 +32,15 @@ const Markers = React.memo(({ bridgeData, setViewport }) => {
               <div key={index}>
                 <Popup
                   key={index}
-                  latitude={marker.lat}
-                  longitude={marker.long}
+                  latitude={marker.Lat}
+                  longitude={marker.Long}
                   anchor="bottom-right"
                 >
                   <div className="popup">
                     {/* This is the information where stackholder found them most valuable*/}
                     <p>Province: {marker.province}</p>
                     <p>District: {marker.district}</p>
-                    <p>Status: {marker.project_stage}</p>
+                    <p>Status: {marker.stage}</p>
                     {/* bridge site name is coming soon */}
                   </div>
                 </Popup>

--- a/src/components/pages/DataViz/RenderMap.js
+++ b/src/components/pages/DataViz/RenderMap.js
@@ -3,6 +3,7 @@ import 'react-map-gl-geocoder/dist/mapbox-gl-geocoder.css';
 import { MenuOutlined } from '@ant-design/icons';
 import useKeypress from '../../common/UseKeypress';
 import bridgeIconGreen from '../../../styles/imgs/bridgeIconGreen.png';
+import RejectedBridges from '../../../styles/imgs/RejectedBridges.png';
 import React, { useState, useRef, useContext } from 'react';
 import ReactMapGL, {
   FullscreenControl,
@@ -31,7 +32,7 @@ const RenderMap = () => {
   const [viewport, setViewport] = useState({
     latitude: -1.9444,
     longitude: 30.0616,
-    zoom: 7.8,
+    zoom: 3.1,
     bearing: 0,
     pitch: 0,
   });
@@ -175,6 +176,7 @@ const RenderMap = () => {
       setFullscreen(false);
     }
   }
+
   return (
     <div className="mapbox-react">
       <ReactMapGL


### PR DESCRIPTION
Not a lot of code needed to be added to fix this issue because the settings in mapbox are already dynamic meaning the size of the device used to view the map the zoom will be closer to the desired default zoom just by changing one setting. Now you should see all or most of Africa on load unless you are on a phone or tablet. 